### PR TITLE
Adds basic Doctype support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![crate_name="xml5ever"]
 #![crate_type="dylib"]
 
-#![cfg_attr(feature = "unstable", feature(plugin, rc_weak))]
+#![cfg_attr(feature = "unstable", feature(plugin))]
 #![cfg_attr(feature = "unstable", plugin(string_cache_plugin))]
 
 #[macro_use] extern crate log;

--- a/src/tokenizer/interface.rs
+++ b/src/tokenizer/interface.rs
@@ -52,7 +52,6 @@ pub struct Doctype {
     pub name: Option<StrTendril>,
     pub public_id: Option<StrTendril>,
     pub system_id: Option<StrTendril>,
-    pub force_quirks: bool,
 }
 
 impl Doctype {
@@ -61,7 +60,6 @@ impl Doctype {
             name: None,
             public_id: None,
             system_id: None,
-            force_quirks: false,
         }
     }
 }

--- a/src/tokenizer/mod.rs
+++ b/src/tokenizer/mod.rs
@@ -495,7 +495,6 @@ macro_rules! shorthand (
     ( $me:ident : push_doctype_name $c:expr        ) => ( option_push(&mut $me.current_doctype.name, $c);      );
     ( $me:ident : push_doctype_id $k:ident $c:expr ) => ( option_push($me.doctype_id($k), $c);                 );
     ( $me:ident : clear_doctype_id $k:ident        ) => ( $me.clear_doctype_id($k);                            );
-    ( $me:ident : force_quirks                     ) => ( $me.current_doctype.force_quirks = true;             );
     ( $me:ident : emit_doctype                     ) => ( $me.emit_current_doctype();                          );
     ( $me:ident : error                            ) => ( $me.bad_char_error();                                );
     ( $me:ident : error_eof                        ) => ( $me.bad_eof_error();                                 );
@@ -875,7 +874,7 @@ impl<Sink: XTokenSink> XmlTokenizer<Sink> {
                     match get_char!(self) {
                         '\t' | '\n' | '\x0C' | ' ' => (),
                         '>' => go!(self: emit_doctype; to XData),
-                        _   => go!(self: error; force_quirks; to BogusDoctype),
+                        _   => go!(self: error; to BogusDoctype),
                     }
                 }
             },

--- a/src/tokenizer/states.rs
+++ b/src/tokenizer/states.rs
@@ -1,10 +1,11 @@
 pub use self::AttrValueKind::*;
 pub use self::XmlState::*;
+pub use self::DoctypeKind::*;
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Copy, Clone, Hash, Debug)]
-pub enum QuoteKind {
-    SingleQuotes,
-    DoubleQuotes,
+pub enum DoctypeKind {
+    Public,
+    System,
 }
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Copy, Clone, Hash, Debug)]
@@ -26,7 +27,6 @@ pub enum XmlState {
     Cdata,
     CdataBracket,
     CdataEnd,
-    XDoctype,
     XTagName,
     XTagEmpty,
     TagAttrNameBefore,
@@ -34,6 +34,17 @@ pub enum XmlState {
     TagAttrNameAfter,
     TagAttrValueBefore,
     TagAttrValue(AttrValueKind),
+    XDoctype,
+    BeforeDoctypeName,
+    DoctypeName,
+    AfterDoctypeName,
+    AfterDoctypeKeyword(DoctypeKind),
+    BeforeDoctypeIdentifier(DoctypeKind),
+    DoctypeIdentifierDoubleQuoted(DoctypeKind),
+    DoctypeIdentifierSingleQuoted(DoctypeKind),
+    AfterDoctypeIdentifier(DoctypeKind),
+    BetweenDoctypePublicAndSystemIdentifiers,
+    BogusDoctype,
     BogusXComment,
 }
 

--- a/tests/tokenizer.rs
+++ b/tests/tokenizer.rs
@@ -27,7 +27,7 @@ use xml5ever::tokenizer::{Attribute};
 use xml5ever::tokenizer::{XTag, StartXTag, EndXTag, CommentXToken, EmptyXTag, ShortXTag};
 use xml5ever::tokenizer::{XToken, CharacterXTokens, XTokenSink};
 use xml5ever::tokenizer::{NullCharacterXToken, XParseError, XTagToken};
-use xml5ever::tokenizer::{PIToken, XPi};
+use xml5ever::tokenizer::{PIToken, XPi, DoctypeXToken, Doctype};
 use xml5ever::tokenizer::{EOFXToken, XmlTokenizer, XmlTokenizerOpts};
 
 mod util {
@@ -245,6 +245,12 @@ fn json_to_xtoken(js: &Json) -> XToken {
         "PI" => PIToken(XPi {
             target: args[0].get_tendril(),
             data: args[1].get_tendril(),
+        }),
+
+        "DOCTYPE" => DoctypeXToken (Doctype{
+            name: args[0].get_nullable_tendril(),
+            public_id: args[1].get_nullable_tendril(),
+            system_id: args[2].get_nullable_tendril(),
         }),
 
         // We don't need to produce NullCharacterToken because


### PR DESCRIPTION
Adds support for Doctype.

Note that during tree building, finding Doctype will always error. First part of attempt to add : Ygg01/xml5_draft#2
