### PR TITLE
Fix rendering for markdown bullet points.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,12 +17,14 @@
 //! You can check out full specification [here](https://ygg01.github.io/xml5_draft/).
 //!
 //! What this library provides is a solid XML parser that can:
+//!
 //!   * Parse somewhat erroneous XML input
 //!   * Provide support for [Numeric character references](https://en.wikipedia.org/wiki/Numeric_character_reference).
 //!   * Provide partial [XML namespace](http://www.w3.org/TR/xml-names11/) support.
 //!   * Provide full set of SVG/MathML entities
 //!
 //! What isn't in scope for this library:
+//!
 //!   * Document Type Definition parsing - this is pretty hard to do right and nowadays, its used
 //!
 


### PR DESCRIPTION
Markdown requires a blank line before bullet points in order to get rendered properly.