### PR TITLE
tree_builder/rules: process namespaces when closing tags

### DIFF
--- a/src/tokenizer/mod.rs
+++ b/src/tokenizer/mod.rs
@@ -30,7 +30,7 @@ use tendril::StrTendril;
 use self::buffer_queue::{BufferQueue, SetResult, FromSet, NotFromSet};
 use self::char_ref::{CharRefTokenizer, CharRef};
 use self::states::{Unquoted, SingleQuoted, DoubleQuoted};
-use self::states::{Data, TagState, XmlState};
+use self::states::{XmlState};
 use self::states::{DoctypeKind, Public, System};
 use self::qname::{QNameTokenizer};
 use util::smallcharset::SmallCharSet;

--- a/src/tree_builder/rules.rs
+++ b/src/tree_builder/rules.rs
@@ -119,10 +119,14 @@ impl<Handle, Sink> XmlTreeBuilderStep
                     self.append_tag(tag)
                 },
                 TagToken(Tag{kind: EndTag, name, attrs}) => {
-                    let tag = Tag {
-                        kind: EndTag,
-                        name: name,
-                        attrs: attrs,
+                    let tag = {
+			let mut tag = Tag {
+                            kind: EndTag,
+                            name: name,
+                            attrs: attrs,
+			};
+			self.process_namespaces(&mut tag);
+			tag
                     };
                     let retval = self.close_tag(tag);
                     if self.no_open_elems() {


### PR DESCRIPTION
Without this, in XmlTreeBuilder `tag_in_open_elems` always returns false
when called in `close_tag`, (as `tag_in_open_elems` checks not just the
`local` Atom, but the namespace), and we never pop the current tag.

There is a PR with a test for this at Ygg01/xml5lib-tests#1