### PR TITLE
Bump version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xml5ever"
-version = "0.1.1"
+version = "0.1.2"
 description = "Push based streaming parser for xml"
 homepage = "https://github.com/Ygg01/xml5ever/blob/master/README.md"
 documentation = "https://ygg01.github.io/docs/xml5ever/xml5ever/index.html"


### PR DESCRIPTION
Fast-forward the "master" branch to the "v0.1.2" tag.