### PR TITLE
Fix parser error when closing script tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
   - Bug in namespace parsing of end tag from @bpowers
   - Removed mention of `one_input` from README.md from @Ygg01
+
+## [0.1.3] - 2016-05-04
+### Fixed
+  - `complete_script` popped the open script tag instead of getting the current node

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xml5ever"
-version = "0.1.2"
+version = "0.1.3"
 description = "Push based streaming parser for xml"
 homepage = "https://github.com/Ygg01/xml5ever/blob/master/README.md"
 documentation = "https://ygg01.github.io/docs/xml5ever/xml5ever/index.html"

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Add xml5ever as a dependency in your project manifest.
 
 ```toml
     [dependencies]
-    xml5ever = "0.1.1"
+    xml5ever = "0.1.3"
 ```
 
 And add crate declaration in your lib.rs

--- a/src/tree_builder/actions.rs
+++ b/src/tree_builder/actions.rs
@@ -231,7 +231,7 @@ impl<Handle, Sink> XmlTreeBuilderActions<Handle>
     }
 
     fn complete_script(&mut self) {
-        let current = self.pop();
+        let current = self.current_node();
         if self.sink.complete_script(current) == NextParserState::Suspend {
             self.next_tokenizer_state = Some(Quiescent);
         }


### PR DESCRIPTION
Fixes an issue that causes any xhtml document with script tags to trigger a parse error.

servo/servo#10939