### PR TITLE
Update html5ever-atoms to 0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,3 +54,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [0.3.2] - 2017-01-11
 ### Changed
   - Replaced `println!` with `debug!`in tokenizer @Freyskeyd
+
+## [0.4.0] - 2017-02-17
+### Changed
+  - Updated html5ever-atoms to 0.2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xml5ever"
-version = "0.3.2"
+version = "0.4.0"
 description = "Push based streaming parser for xml"
 homepage = "https://github.com/Ygg01/xml5ever/blob/master/README.md"
 documentation = "https://ygg01.github.io/docs/xml5ever/xml5ever/index.html"
@@ -21,7 +21,7 @@ log = "0"
 phf = "0.7"
 mac = "0"
 tendril = "0.2"
-html5ever-atoms = "0.1"
+html5ever-atoms = "0.2"
 
 [dev-dependencies]
 rustc-serialize = "0.3.15"


### PR DESCRIPTION
Blocked by https://github.com/servo/html5ever/pull/251.